### PR TITLE
Updates for August 2024

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,9 +157,6 @@
             <p>
               Second and Fourth Sundays: From the Denson book, 4-6 PM at McMenamins Kennedy School, 5736 NE 33rd Ave, Portland, OR. Singing is in the Community Room at the SE corner of the main building.
             </p>
-            <p>
-              Third Thursdays: From the Shenandoah Harmony, 7-9 PM at There Be Monsters, 1308 SE Morrison St, Portland, OR. Singing is in the back room, past the shuffleboard table.
-            </p>
           </div>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
                 <li><a href="#about" class="smoothscroll">About</a></li>
                 <li><a href="#calendar" class="smoothscroll">Calendar</a></li>
                 <li><a href="#colophon" class="smoothscroll">Contact</a></li>
-                <li><a href="convention.html" target="_blank"><b>Double All Day</b></a></li>
+                <li><a href="convention.html" target="_blank"><b>All Day Singings</b></a></li>
             </ul>
         </nav> <!-- end s-header__nav -->
 


### PR DESCRIPTION
- Double All Day -> All Day Singings on main page
- Shenandoah Harmony singings are not currently happening
